### PR TITLE
Make input and select elements full-width

### DIFF
--- a/libs/currency-converter/src/lib/components/currency-converter.component.html
+++ b/libs/currency-converter/src/lib/components/currency-converter.component.html
@@ -8,7 +8,7 @@
               Währung
             </div>
             <select
-              class="select select-bordered select-lg"
+              class="select select-bordered select-lg w-full"
               formControlName="fromCurrency"
             >
               @for (contents of currencies(); track contents[0]) {
@@ -23,7 +23,7 @@
               Menge
             </div>
             <input
-              class="input input-bordered input-lg"
+              class="input input-bordered input-lg w-full"
               formControlName="amount"
               type="text"
             />
@@ -33,7 +33,7 @@
           <label>
             <div class="mb-2">Währung</div>
             <select
-              class="select select-bordered select-lg"
+              class="select select-bordered select-lg w-full"
               formControlName="toCurrency"
             >
               @for (contents of currencies(); track contents[0]) {
@@ -48,7 +48,7 @@
               Menge
             </div>
             <input
-              class="input input-bordered input-lg"
+              class="input input-bordered input-lg w-full"
               formControlName="result"
               type="text"
             />

--- a/libs/url-rewrites/src/lib/components/url-rewrites.component.html
+++ b/libs/url-rewrites/src/lib/components/url-rewrites.component.html
@@ -11,7 +11,7 @@
                 </div>
                 <input
                   type="url"
-                  class="input input-bordered input-lg"
+                  class="input input-bordered input-lg w-full"
                   placeholder="https://old-url.com"
                   formControlName="oldUrl"
                   [attr.id]="'oldUrl_' + $index"
@@ -24,7 +24,7 @@
                 </div>
                 <input
                   type="url"
-                  class="input input-bordered input-lg"
+                  class="input input-bordered input-lg w-full"
                   placeholder="https://new-url.com"
                   formControlName="newUrl"
                   [attr.id]="'newUrl_' + $index"


### PR DESCRIPTION
Ensure consistent styling across forms by adding the `w-full` class to input and select elements. This enhances layout responsiveness and improves user experience, particularly on smaller screens.